### PR TITLE
Add campaign mode and unlockable items UI (#80)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { GameScene } from './scenes/GameScene'
 import { UIScene } from './scenes/UIScene'
 import { StatisticsScene } from './scenes/StatisticsScene'
 import { ControlsScene } from './scenes/ControlsScene'
+import { UnlockScene } from './scenes/UnlockScene'
 
 const config: Phaser.Types.Core.GameConfig = {
 	type: Phaser.WEBGL,
@@ -32,7 +33,7 @@ const config: Phaser.Types.Core.GameConfig = {
 	audio: {
 		disableWebAudio: false
 	},
-	scene: [StartScene, ControlsScene, GameScene, StatisticsScene, UIScene]
+	scene: [StartScene, ControlsScene, GameScene, StatisticsScene, UIScene, UnlockScene]
 }
 
 new Phaser.Game(config) 

--- a/src/scenes/PathGenerator.ts
+++ b/src/scenes/PathGenerator.ts
@@ -151,14 +151,13 @@ export class PathGenerator {
         const waypoints: Phaser.Math.Vector2[] = [];
 
         // Start point - always from the left edge of the map
-        let startX: number;
         let startY: number;
         
         // Determine starting edge based on path index
         const startEdge = this.determineStartEdge(pathIndex, totalPaths);
         
         // Always start from the left edge (x = 0)
-        startX = 0;
+        const startX = 0;
         
         if (startEdge === 'top') {
             // Start from left edge at top of safe area

--- a/src/scenes/PathGenerator.ts
+++ b/src/scenes/PathGenerator.ts
@@ -150,25 +150,24 @@ export class PathGenerator {
         // Now build path from left to right, ensuring all segments are horizontal or vertical
         const waypoints: Phaser.Math.Vector2[] = [];
 
-        // Start point - can be from left edge, top, or bottom in first third of map
-        const firstThirdX = mapWidth / 3;
+        // Start point - always from the left edge of the map
         let startX: number;
         let startY: number;
         
         // Determine starting edge based on path index
         const startEdge = this.determineStartEdge(pathIndex, totalPaths);
         
+        // Always start from the left edge (x = 0)
+        startX = 0;
+        
         if (startEdge === 'top') {
-            // Start from top edge within first third
-            startX = Phaser.Math.Between(this.margin, firstThirdX);
+            // Start from left edge at top of safe area
             startY = minY;
         } else if (startEdge === 'bottom') {
-            // Start from bottom edge within first third
-            startX = Phaser.Math.Between(this.margin, firstThirdX);
+            // Start from left edge at bottom of safe area
             startY = maxY;
         } else {
-            // Start from left edge
-            startX = 0;
+            // Start from left edge with varied Y position
             if (totalPaths === 1) {
                 // Single path: random starting Y
                 startY = Phaser.Math.Between(minY, maxY);
@@ -188,8 +187,8 @@ export class PathGenerator {
         waypoints.push(new Phaser.Math.Vector2(currentX, currentY));
 
         // Alternate between horizontal and vertical movements
-        // If starting from top or bottom edge, first movement should be vertical to enter play area
-        let isHorizontal = startEdge === 'left'; // Start horizontal only from left edge
+        // Since all paths now start from left edge, first movement should always be horizontal
+        let isHorizontal = true; // Always start with horizontal movement from left edge
         let turnsRemaining = numberOfTurningPoints;
 
         // Define strict separated zones for each path

--- a/src/scenes/StartScene.ts
+++ b/src/scenes/StartScene.ts
@@ -391,6 +391,166 @@ export class StartScene extends Phaser.Scene {
 	}
 
 	private startGame(): void {
+		// Show mode selection UI
+		this.showModeSelection()
+	}
+
+	private showModeSelection(): void {
+		const centerX = this.scale.width / 2
+		const centerY = this.scale.height / 2
+
+		// Create a semi-transparent overlay
+		const overlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.85)
+		overlay.setOrigin(0, 0)
+		overlay.setDepth(100)
+
+		// Create container for mode selection UI
+		const modeContainer = this.add.container(0, 0)
+		modeContainer.setDepth(101)
+
+		// Title
+		const title = this.add.text(centerX, centerY - 180, 'SELECT GAME MODE', {
+			fontSize: '48px',
+			color: '#00d4ff',
+			fontFamily: 'Arial, sans-serif',
+			fontStyle: 'bold',
+			resolution: 2
+		})
+		title.setOrigin(0.5)
+		title.setStroke('#001a33', 6)
+		modeContainer.add(title)
+
+		// Mode buttons configuration
+		const modes = [
+			{
+				id: 'quick-defense' as const,
+				name: 'Quick Defense',
+				description: 'Jump straight into action!\nDefend your base in a fast-paced battle.',
+				yOffset: -40
+			},
+			{
+				id: 'campaign' as const,
+				name: 'Campaign Mode',
+				description: 'Embark on an epic journey!\nMore features coming soon.',
+				yOffset: 80
+			}
+		]
+
+		modes.forEach((mode) => {
+			const buttonY = centerY + mode.yOffset
+			const buttonWidth = 400
+			const buttonHeight = 90
+
+			// Button background
+			const buttonBg = this.add.rectangle(centerX, buttonY, buttonWidth, buttonHeight, 0x00d4ff, 0.2)
+			buttonBg.setStrokeStyle(3, 0x00d4ff)
+			buttonBg.setInteractive({ useHandCursor: true })
+			modeContainer.add(buttonBg)
+
+			// Button title
+			const buttonTitle = this.add.text(centerX, buttonY - 20, mode.name, {
+				fontSize: '28px',
+				color: '#00d4ff',
+				fontFamily: 'Arial, sans-serif',
+				fontStyle: 'bold',
+				resolution: 2
+			})
+			buttonTitle.setOrigin(0.5)
+			modeContainer.add(buttonTitle)
+
+			// Button description
+			const buttonDesc = this.add.text(centerX, buttonY + 15, mode.description, {
+				fontSize: '14px',
+				color: '#88ccff',
+				fontFamily: 'Arial, sans-serif',
+				align: 'center',
+				resolution: 2
+			})
+			buttonDesc.setOrigin(0.5)
+			modeContainer.add(buttonDesc)
+
+			// Hover effects
+			buttonBg.on('pointerover', () => {
+				buttonBg.setFillStyle(0x00d4ff, 0.4)
+				buttonTitle.setColor('#ffffff')
+				buttonDesc.setColor('#ffffff')
+				this.tweens.add({
+					targets: [buttonBg, buttonTitle, buttonDesc],
+					scale: 1.05,
+					duration: 200,
+					ease: 'Power2'
+				})
+			})
+
+			buttonBg.on('pointerout', () => {
+				buttonBg.setFillStyle(0x00d4ff, 0.2)
+				buttonTitle.setColor('#00d4ff')
+				buttonDesc.setColor('#88ccff')
+				this.tweens.add({
+					targets: [buttonBg, buttonTitle, buttonDesc],
+					scale: 1,
+					duration: 200,
+					ease: 'Power2'
+				})
+			})
+
+			// Click handler
+			buttonBg.on('pointerdown', () => {
+				this.selectGameMode(mode.id, overlay, modeContainer)
+			})
+		})
+
+		// Back button
+		const backButtonY = centerY + 180
+		const backButton = this.add.text(centerX, backButtonY, '< Back', {
+			fontSize: '20px',
+			color: '#666666',
+			fontFamily: 'Arial, sans-serif',
+			resolution: 2
+		})
+		backButton.setOrigin(0.5)
+		backButton.setInteractive({ useHandCursor: true })
+		modeContainer.add(backButton)
+
+		backButton.on('pointerover', () => {
+			backButton.setColor('#00d4ff')
+		})
+
+		backButton.on('pointerout', () => {
+			backButton.setColor('#666666')
+		})
+
+		backButton.on('pointerdown', () => {
+			// Fade out and destroy the mode selection UI
+			this.tweens.add({
+				targets: [overlay, modeContainer],
+				alpha: 0,
+				duration: 300,
+				onComplete: () => {
+					overlay.destroy()
+					modeContainer.destroy()
+				}
+			})
+		})
+
+		// Entrance animation
+		overlay.setAlpha(0)
+		modeContainer.setAlpha(0)
+
+		this.tweens.add({
+			targets: [overlay, modeContainer],
+			alpha: 1,
+			duration: 300,
+			ease: 'Power2'
+		})
+	}
+
+	private selectGameMode(mode: 'quick-defense' | 'campaign', overlay: Phaser.GameObjects.Rectangle, container: Phaser.GameObjects.Container): void {
+		// Store the selected mode
+		console.log('🎮 Setting game mode to:', mode)
+		this.gameConfigService.setGameMode(mode)
+		console.log('🎮 Game mode confirmed:', this.gameConfigService.getGameMode())
+
 		// Play funny start sound!
 		this.playStartSound()
 
@@ -399,6 +559,13 @@ export class StartScene extends Phaser.Scene {
 			this.musicGain.gain.setValueAtTime(this.musicGain.gain.value, this.audioContext.currentTime)
 			this.musicGain.gain.linearRampToValueAtTime(0, this.audioContext.currentTime + 0.5)
 		}
+
+		// Fade out the mode selection UI
+		this.tweens.add({
+			targets: [overlay, container],
+			alpha: 0,
+			duration: 300
+		})
 
 		// Fade out effect
 		this.cameras.main.fadeOut(500, 0, 0, 0)

--- a/src/scenes/UnlockScene.ts
+++ b/src/scenes/UnlockScene.ts
@@ -1,0 +1,436 @@
+import Phaser from 'phaser';
+import { CampaignProgressionService, UnlockableItem } from '../services/CampaignProgressionService';
+import { GAME_EVENTS } from './GameScene';
+
+export class UnlockScene extends Phaser.Scene {
+    static KEY = 'UnlockScene';
+    private campaignProgressionService: CampaignProgressionService;
+    private overlay?: Phaser.GameObjects.Rectangle;
+    private mainContainer?: Phaser.GameObjects.Container;
+    private itemContainers: Map<string, Phaser.GameObjects.Container> = new Map();
+
+    constructor() {
+        super(UnlockScene.KEY);
+        this.campaignProgressionService = CampaignProgressionService.getInstance();
+    }
+
+    create(): void {
+        // Semi-transparent overlay
+        this.overlay = this.add.rectangle(
+            0,
+            0,
+            this.scale.width,
+            this.scale.height,
+            0x000000,
+            0.85
+        );
+        this.overlay.setOrigin(0, 0);
+        this.overlay.setDepth(100);
+        this.overlay.setInteractive(); // Block clicks to game scene below
+
+        // Main container
+        this.mainContainer = this.add.container(0, 0);
+        this.mainContainer.setDepth(101);
+
+        // Create UI
+        this.createHeader();
+        this.createUnlockableItems();
+        this.createCloseButton();
+
+        // Listen for campaign points changes
+        this.game.events.on(GAME_EVENTS.campaignPointsChanged, () => {
+            this.updateUnlockableItems();
+        });
+
+        // Listen for ESC key to close
+        this.input.keyboard?.on('keydown-ESC', () => {
+            this.closeUI();
+        });
+        
+        // Listen for U key to close
+        this.input.keyboard?.on('keydown-U', () => {
+            this.closeUI();
+        });
+
+        // Entrance animation
+        this.mainContainer.setAlpha(0);
+        this.overlay.setAlpha(0);
+        this.tweens.add({
+            targets: [this.mainContainer, this.overlay],
+            alpha: { from: 0, to: 1 },
+            duration: 300,
+            ease: 'Power2'
+        });
+    }
+
+    private createHeader(): void {
+        const centerX = this.scale.width / 2;
+        const headerY = 80;
+
+        // Title
+        const title = this.add.text(centerX, headerY, 'Campaign Unlocks', {
+            fontSize: '48px',
+            color: '#00d4ff',
+            fontFamily: 'Arial, sans-serif',
+            fontStyle: 'bold',
+            stroke: '#001a33',
+            strokeThickness: 6,
+            resolution: 2
+        });
+        title.setOrigin(0.5);
+        this.mainContainer?.add(title);
+
+        // Campaign points display
+        const points = this.campaignProgressionService.getCampaignPoints();
+        const pointsText = this.add.text(
+            centerX,
+            headerY + 50,
+            `Available Points: ${points} ⭐`,
+            {
+                fontSize: '24px',
+                color: '#ffd700',
+                fontFamily: 'Arial, sans-serif',
+                fontStyle: 'bold',
+                stroke: '#000000',
+                strokeThickness: 3,
+                resolution: 2
+            }
+        );
+        pointsText.setOrigin(0.5);
+        pointsText.setName('points_display');
+        this.mainContainer?.add(pointsText);
+    }
+
+    private createUnlockableItems(): void {
+        const centerX = this.scale.width / 2;
+        const startY = 200;
+        
+        // Get all unlockable items
+        const towers = this.campaignProgressionService.getUnlockableItemsByType('tower');
+        const skills = this.campaignProgressionService.getUnlockableItemsByType('skill');
+
+        // Create two columns: Towers on the left, Skills on the right
+        const columnWidth = 400;
+        const leftX = centerX - columnWidth / 2 - 50;
+        const rightX = centerX + columnWidth / 2 + 50;
+
+        // Towers column
+        const towersTitle = this.add.text(leftX, startY, 'Towers', {
+            fontSize: '32px',
+            color: '#ff6348',
+            fontFamily: 'Arial, sans-serif',
+            fontStyle: 'bold',
+            stroke: '#000000',
+            strokeThickness: 3,
+            resolution: 2
+        });
+        towersTitle.setOrigin(0.5);
+        this.mainContainer?.add(towersTitle);
+
+        let towerY = startY + 50;
+        towers.forEach((item) => {
+            this.createUnlockableItemCard(item, leftX, towerY);
+            towerY += 120;
+        });
+
+        // Skills column
+        const skillsTitle = this.add.text(rightX, startY, 'Skills', {
+            fontSize: '32px',
+            color: '#9b59b6',
+            fontFamily: 'Arial, sans-serif',
+            fontStyle: 'bold',
+            stroke: '#000000',
+            strokeThickness: 3,
+            resolution: 2
+        });
+        skillsTitle.setOrigin(0.5);
+        this.mainContainer?.add(skillsTitle);
+
+        let skillY = startY + 50;
+        skills.forEach((item) => {
+            this.createUnlockableItemCard(item, rightX, skillY);
+            skillY += 120;
+        });
+    }
+
+    private createUnlockableItemCard(item: UnlockableItem, x: number, y: number): void {
+        const cardWidth = 380;
+        const cardHeight = 100;
+
+        const cardContainer = this.add.container(x, y);
+        cardContainer.setName(`card_${item.id}`);
+
+        // Check unlock status
+        const isUnlocked = item.type === 'tower' && item.towerTypeId
+            ? this.campaignProgressionService.isTowerUnlocked(item.towerTypeId)
+            : this.campaignProgressionService.isSkillUnlocked(item.id);
+        
+        const canAfford = this.campaignProgressionService.canUnlockItem(item.id);
+
+        // Background
+        const bgColor = isUnlocked ? 0x2a4a2e : (canAfford ? 0x1a1a2e : 0x2e1a1a);
+        const bg = this.add.rectangle(0, 0, cardWidth, cardHeight, bgColor, 0.95);
+        bg.setStrokeStyle(2, isUnlocked ? 0x00ff00 : (canAfford ? 0x00d4ff : 0x666666));
+        bg.setName('bg');
+        if (!isUnlocked && canAfford) {
+            bg.setInteractive({ useHandCursor: true });
+        }
+        cardContainer.add(bg);
+
+        // Status indicator (lock/check)
+        const statusIcon = this.add.text(-cardWidth / 2 + 20, 0, isUnlocked ? '✓' : '🔒', {
+            fontSize: '32px',
+            resolution: 2
+        });
+        statusIcon.setOrigin(0.5);
+        cardContainer.add(statusIcon);
+
+        // Item name
+        const nameText = this.add.text(-cardWidth / 2 + 60, -20, item.name, {
+            fontSize: '18px',
+            color: isUnlocked ? '#00ff00' : '#ffffff',
+            fontFamily: 'Arial, sans-serif',
+            fontStyle: 'bold',
+            resolution: 2
+        });
+        nameText.setOrigin(0, 0.5);
+        cardContainer.add(nameText);
+
+        // Item description
+        const descText = this.add.text(-cardWidth / 2 + 60, 5, item.description, {
+            fontSize: '14px',
+            color: '#cccccc',
+            fontFamily: 'Arial, sans-serif',
+            wordWrap: { width: cardWidth - 80 },
+            resolution: 2
+        });
+        descText.setOrigin(0, 0.5);
+        cardContainer.add(descText);
+
+        // Cost display
+        if (!isUnlocked) {
+            const costText = this.add.text(cardWidth / 2 - 20, 30, `${item.cost} ⭐`, {
+                fontSize: '20px',
+                color: canAfford ? '#ffd700' : '#666666',
+                fontFamily: 'Arial, sans-serif',
+                fontStyle: 'bold',
+                stroke: '#000000',
+                strokeThickness: 2,
+                resolution: 2
+            });
+            costText.setOrigin(1, 0.5);
+            costText.setName('cost');
+            cardContainer.add(costText);
+        } else {
+            const unlockedText = this.add.text(cardWidth / 2 - 20, 30, 'UNLOCKED', {
+                fontSize: '16px',
+                color: '#00ff00',
+                fontFamily: 'Arial, sans-serif',
+                fontStyle: 'bold',
+                stroke: '#000000',
+                strokeThickness: 2,
+                resolution: 2
+            });
+            unlockedText.setOrigin(1, 0.5);
+            cardContainer.add(unlockedText);
+        }
+
+        // Hover effect
+        if (!isUnlocked && canAfford) {
+            bg.on('pointerover', () => {
+                bg.setFillStyle(0x2a3a4e, 0.95);
+                this.tweens.add({
+                    targets: cardContainer,
+                    scale: 1.05,
+                    duration: 200,
+                    ease: 'Power2'
+                });
+            });
+
+            bg.on('pointerout', () => {
+                bg.setFillStyle(bgColor, 0.95);
+                this.tweens.add({
+                    targets: cardContainer,
+                    scale: 1,
+                    duration: 200,
+                    ease: 'Power2'
+                });
+            });
+
+            // Click to unlock
+            bg.on('pointerdown', () => {
+                this.unlockItem(item);
+            });
+        }
+
+        this.mainContainer?.add(cardContainer);
+        this.itemContainers.set(item.id, cardContainer);
+    }
+
+    private unlockItem(item: UnlockableItem): void {
+        const success = this.campaignProgressionService.unlockItem(item.id);
+        
+        if (success) {
+            // Show success message
+            const centerX = this.scale.width / 2;
+            const centerY = this.scale.height / 2;
+            
+            const successText = this.add.text(
+                centerX,
+                centerY,
+                `${item.name} Unlocked!`,
+                {
+                    fontSize: '36px',
+                    color: '#00ff00',
+                    fontFamily: 'Arial, sans-serif',
+                    fontStyle: 'bold',
+                    stroke: '#000000',
+                    strokeThickness: 4,
+                    resolution: 2
+                }
+            );
+            successText.setOrigin(0.5);
+            successText.setDepth(200);
+
+            this.tweens.add({
+                targets: successText,
+                alpha: 0,
+                y: centerY - 50,
+                duration: 1500,
+                ease: 'Power2',
+                onComplete: () => {
+                    successText.destroy();
+                }
+            });
+
+            // Emit campaign points changed event to update other UI
+            this.game.events.emit(GAME_EVENTS.campaignPointsChanged);
+
+            // Update all unlock cards
+            this.updateUnlockableItems();
+            
+            // If it's a tower, recreate the tower store UI
+            if (item.type === 'tower') {
+                // Signal UI scene to refresh tower cards
+                this.scene.get('UIScene').scene.restart();
+            }
+        }
+    }
+
+    private updateUnlockableItems(): void {
+        // Update points display
+        if (this.mainContainer) {
+            const pointsDisplay = this.mainContainer.getByName('points_display') as Phaser.GameObjects.Text;
+            if (pointsDisplay) {
+                const points = this.campaignProgressionService.getCampaignPoints();
+                pointsDisplay.setText(`Available Points: ${points} ⭐`);
+            }
+        }
+
+        // Update all item cards
+        this.itemContainers.forEach((container, itemId) => {
+            const item = this.campaignProgressionService.getUnlockableItem(itemId);
+            if (!item) return;
+
+            const isUnlocked = item.type === 'tower' && item.towerTypeId
+                ? this.campaignProgressionService.isTowerUnlocked(item.towerTypeId)
+                : this.campaignProgressionService.isSkillUnlocked(item.id);
+            
+            const canAfford = this.campaignProgressionService.canUnlockItem(item.id);
+
+            // Update background
+            const bg = container.getByName('bg') as Phaser.GameObjects.Rectangle;
+            if (bg) {
+                const bgColor = isUnlocked ? 0x2a4a2e : (canAfford ? 0x1a1a2e : 0x2e1a1a);
+                bg.setFillStyle(bgColor, 0.95);
+                bg.setStrokeStyle(2, isUnlocked ? 0x00ff00 : (canAfford ? 0x00d4ff : 0x666666));
+            }
+
+            // Update cost text if present
+            const costText = container.getByName('cost') as Phaser.GameObjects.Text;
+            if (costText) {
+                costText.setColor(canAfford ? '#ffd700' : '#666666');
+            }
+        });
+    }
+
+    private createCloseButton(): void {
+        const centerX = this.scale.width / 2;
+        const bottomY = this.scale.height - 60;
+        const buttonWidth = 200;
+        const buttonHeight = 50;
+
+        // Close button background
+        const closeBg = this.add.rectangle(
+            centerX,
+            bottomY,
+            buttonWidth,
+            buttonHeight,
+            0xff4757,
+            0.3
+        );
+        closeBg.setStrokeStyle(2, 0xff4757);
+        closeBg.setInteractive({ useHandCursor: true });
+        this.mainContainer?.add(closeBg);
+
+        // Close button text
+        const closeText = this.add.text(centerX, bottomY, 'Close [ESC]', {
+            fontSize: '24px',
+            color: '#ff4757',
+            fontFamily: 'Arial, sans-serif',
+            fontStyle: 'bold',
+            resolution: 2
+        });
+        closeText.setOrigin(0.5);
+        this.mainContainer?.add(closeText);
+
+        // Hover effects
+        closeBg.on('pointerover', () => {
+            closeBg.setFillStyle(0xff4757, 0.6);
+            closeText.setColor('#ffffff');
+            this.tweens.add({
+                targets: [closeBg, closeText],
+                scale: 1.05,
+                duration: 200,
+                ease: 'Power2'
+            });
+        });
+
+        closeBg.on('pointerout', () => {
+            closeBg.setFillStyle(0xff4757, 0.3);
+            closeText.setColor('#ff4757');
+            this.tweens.add({
+                targets: [closeBg, closeText],
+                scale: 1,
+                duration: 200,
+                ease: 'Power2'
+            });
+        });
+
+        // Click handler
+        closeBg.on('pointerdown', () => {
+            this.closeUI();
+        });
+    }
+
+    private closeUI(): void {
+        // Fade out animation
+        this.tweens.add({
+            targets: [this.mainContainer, this.overlay],
+            alpha: 0,
+            duration: 300,
+            ease: 'Power2',
+            onComplete: () => {
+                this.scene.stop();
+            }
+        });
+    }
+
+    shutdown(): void {
+        // Clean up event listeners
+        this.game.events.off(GAME_EVENTS.campaignPointsChanged);
+        this.input.keyboard?.off('keydown-ESC');
+        this.input.keyboard?.off('keydown-U');
+    }
+}
+

--- a/src/services/CampaignProgressionService.ts
+++ b/src/services/CampaignProgressionService.ts
@@ -1,0 +1,437 @@
+import { TowerTypeID } from './TowerStore';
+
+/**
+ * Unlockable items in the campaign
+ */
+export interface UnlockableItem {
+    id: string;
+    name: string;
+    description: string;
+    cost: number; // Cost in campaign points
+    type: 'tower' | 'skill';
+    towerTypeId?: TowerTypeID; // Only for tower unlocks
+}
+
+/**
+ * Campaign progression data
+ */
+interface CampaignProgressionData {
+    campaignPoints: number;
+    totalPointsEarned: number; // Track total points earned for statistics
+    unlockedTowers: Set<TowerTypeID>;
+    unlockedSkills: Set<string>;
+}
+
+/**
+ * CampaignProgressionService - Singleton service to manage campaign progression
+ * 
+ * This service manages:
+ * - Campaign points (earned by killing enemies)
+ * - Unlocked towers and skills
+ * - Persistence using localStorage
+ */
+export class CampaignProgressionService {
+    private static instance: CampaignProgressionService;
+    private static readonly STORAGE_KEY = 'tower_defense_campaign_progress';
+    private static readonly STORAGE_VERSION = 2; // Increment this when changing save format
+    
+    private campaignPoints: number = 0;
+    private totalPointsEarned: number = 0;
+    private unlockedTowers: Set<TowerTypeID> = new Set();
+    private unlockedSkills: Set<string> = new Set();
+    
+    // Define all unlockable items
+    private unlockableItems: Map<string, UnlockableItem> = new Map();
+
+    /**
+     * Private constructor to enforce singleton pattern
+     */
+    private constructor() {
+        this.initializeUnlockables();
+        this.loadProgress();
+        
+        // Expose reset function to window for debugging (in browser console)
+        if (typeof window !== 'undefined') {
+            (window as any).resetCampaign = () => {
+                this.clearAndReset();
+                console.log('✅ Campaign progress has been reset! Reload the page to see changes.');
+            };
+        }
+    }
+
+    /**
+     * Get the singleton instance of CampaignProgressionService
+     */
+    public static getInstance(): CampaignProgressionService {
+        if (!CampaignProgressionService.instance) {
+            CampaignProgressionService.instance = new CampaignProgressionService();
+        }
+        return CampaignProgressionService.instance;
+    }
+
+    /**
+     * Initialize all unlockable items (towers and skills)
+     */
+    private initializeUnlockables(): void {
+        // Tower unlocks (in order of progression)
+        this.unlockableItems.set('tower_chain', {
+            id: 'tower_chain',
+            name: 'Chain Explosion Tower',
+            description: 'Triggers chain explosions between enemies',
+            cost: 100,
+            type: 'tower',
+            towerTypeId: TowerTypeID.CHAIN
+        });
+
+        this.unlockableItems.set('tower_aoe', {
+            id: 'tower_aoe',
+            name: 'AOE Tower',
+            description: 'Creates large area damage explosions',
+            cost: 150,
+            type: 'tower',
+            towerTypeId: TowerTypeID.AOE
+        });
+
+        this.unlockableItems.set('tower_sniper', {
+            id: 'tower_sniper',
+            name: 'Sniper Tower',
+            description: 'Long range, high damage, slow fire rate',
+            cost: 200,
+            type: 'tower',
+            towerTypeId: TowerTypeID.SNIPER
+        });
+
+        this.unlockableItems.set('tower_rapid', {
+            id: 'tower_rapid',
+            name: 'Rapid Fire Tower',
+            description: 'Short range, fast fire rate',
+            cost: 250,
+            type: 'tower',
+            towerTypeId: TowerTypeID.RAPID
+        });
+
+        this.unlockableItems.set('tower_frost', {
+            id: 'tower_frost',
+            name: 'Frost Tower',
+            description: 'Slows enemies down significantly',
+            cost: 300,
+            type: 'tower',
+            towerTypeId: TowerTypeID.FROST
+        });
+
+        // Skill unlocks
+        this.unlockableItems.set('skill_starting_gold', {
+            id: 'skill_starting_gold',
+            name: 'Extra Starting Gold',
+            description: 'Start with +50 gold',
+            cost: 50,
+            type: 'skill'
+        });
+
+        this.unlockableItems.set('skill_gold_bonus', {
+            id: 'skill_gold_bonus',
+            name: 'Gold Rush',
+            description: '+20% gold from enemy kills',
+            cost: 100,
+            type: 'skill'
+        });
+
+        this.unlockableItems.set('skill_tower_discount', {
+            id: 'skill_tower_discount',
+            name: 'Tower Discount',
+            description: '-10% cost for all towers',
+            cost: 150,
+            type: 'skill'
+        });
+
+        this.unlockableItems.set('skill_extra_lives', {
+            id: 'skill_extra_lives',
+            name: 'Extra Lives',
+            description: 'Start with +5 lives',
+            cost: 200,
+            type: 'skill'
+        });
+
+        this.unlockableItems.set('skill_tower_damage', {
+            id: 'skill_tower_damage',
+            name: 'Tower Damage Boost',
+            description: '+15% damage for all towers',
+            cost: 250,
+            type: 'skill'
+        });
+
+        this.unlockableItems.set('skill_tower_range', {
+            id: 'skill_tower_range',
+            name: 'Tower Range Boost',
+            description: '+20% range for all towers',
+            cost: 250,
+            type: 'skill'
+        });
+    }
+
+    /**
+     * Reset campaign progression (for new game or reset)
+     * This clears all progress and starts fresh with only the Basic tower unlocked
+     */
+    public resetProgress(): void {
+        console.log('Resetting campaign progress to default state...');
+        this.campaignPoints = 0;
+        this.totalPointsEarned = 0;
+        this.unlockedTowers.clear();
+        this.unlockedSkills.clear();
+        
+        // Basic tower is always unlocked in campaign mode
+        this.unlockedTowers.add(TowerTypeID.BASIC);
+        
+        this.saveProgress();
+        console.log('Campaign progress reset complete. Only Basic tower is unlocked.');
+    }
+    
+    /**
+     * Force clear all saved data and reset (for debugging or user request)
+     */
+    public clearAndReset(): void {
+        try {
+            localStorage.removeItem(CampaignProgressionService.STORAGE_KEY);
+            console.log('Cleared campaign save data from localStorage');
+        } catch (error) {
+            console.error('Failed to clear campaign save data:', error);
+        }
+        this.resetProgress();
+    }
+
+    /**
+     * Get current campaign points
+     */
+    public getCampaignPoints(): number {
+        return this.campaignPoints;
+    }
+
+    /**
+     * Get total campaign points earned (for statistics)
+     */
+    public getTotalPointsEarned(): number {
+        return this.totalPointsEarned;
+    }
+
+    /**
+     * Add campaign points (called when enemies are killed)
+     */
+    public addCampaignPoints(points: number): void {
+        this.campaignPoints += points;
+        this.totalPointsEarned += points;
+        this.saveProgress();
+    }
+
+    /**
+     * Check if a tower is unlocked
+     */
+    public isTowerUnlocked(towerTypeId: TowerTypeID): boolean {
+        return this.unlockedTowers.has(towerTypeId);
+    }
+
+    /**
+     * Check if a skill is unlocked
+     */
+    public isSkillUnlocked(skillId: string): boolean {
+        return this.unlockedSkills.has(skillId);
+    }
+
+    /**
+     * Unlock an item (tower or skill)
+     * @returns true if unlock was successful, false if not enough points or already unlocked
+     */
+    public unlockItem(itemId: string): boolean {
+        const item = this.unlockableItems.get(itemId);
+        if (!item) {
+            console.error(`Item ${itemId} not found`);
+            return false;
+        }
+
+        // Check if already unlocked
+        if (item.type === 'tower' && item.towerTypeId && this.unlockedTowers.has(item.towerTypeId)) {
+            return false;
+        }
+        if (item.type === 'skill' && this.unlockedSkills.has(itemId)) {
+            return false;
+        }
+
+        // Check if enough points
+        if (this.campaignPoints < item.cost) {
+            return false;
+        }
+
+        // Deduct points and unlock
+        this.campaignPoints -= item.cost;
+        
+        if (item.type === 'tower' && item.towerTypeId) {
+            this.unlockedTowers.add(item.towerTypeId);
+        } else if (item.type === 'skill') {
+            this.unlockedSkills.add(itemId);
+        }
+
+        this.saveProgress();
+        return true;
+    }
+
+    /**
+     * Get all unlockable items
+     */
+    public getAllUnlockableItems(): UnlockableItem[] {
+        return Array.from(this.unlockableItems.values());
+    }
+
+    /**
+     * Get unlockable items by type
+     */
+    public getUnlockableItemsByType(type: 'tower' | 'skill'): UnlockableItem[] {
+        return this.getAllUnlockableItems().filter(item => item.type === type);
+    }
+
+    /**
+     * Get an unlockable item by ID
+     */
+    public getUnlockableItem(itemId: string): UnlockableItem | undefined {
+        return this.unlockableItems.get(itemId);
+    }
+
+    /**
+     * Check if an item can be unlocked (has enough points and not already unlocked)
+     */
+    public canUnlockItem(itemId: string): boolean {
+        const item = this.unlockableItems.get(itemId);
+        if (!item) return false;
+
+        // Check if already unlocked
+        if (item.type === 'tower' && item.towerTypeId && this.unlockedTowers.has(item.towerTypeId)) {
+            return false;
+        }
+        if (item.type === 'skill' && this.unlockedSkills.has(itemId)) {
+            return false;
+        }
+
+        // Check if enough points
+        return this.campaignPoints >= item.cost;
+    }
+
+    /**
+     * Apply skill bonuses to a value
+     */
+    public applySkillBonus(baseValue: number, bonusType: 'gold' | 'damage' | 'range' | 'cost'): number {
+        let multiplier = 1;
+
+        switch (bonusType) {
+            case 'gold':
+                if (this.isSkillUnlocked('skill_gold_bonus')) {
+                    multiplier += 0.2; // +20% gold
+                }
+                break;
+            case 'damage':
+                if (this.isSkillUnlocked('skill_tower_damage')) {
+                    multiplier += 0.15; // +15% damage
+                }
+                break;
+            case 'range':
+                if (this.isSkillUnlocked('skill_tower_range')) {
+                    multiplier += 0.2; // +20% range
+                }
+                break;
+            case 'cost':
+                if (this.isSkillUnlocked('skill_tower_discount')) {
+                    multiplier -= 0.1; // -10% cost
+                }
+                break;
+        }
+
+        return Math.round(baseValue * multiplier);
+    }
+
+    /**
+     * Get starting gold bonus
+     */
+    public getStartingGoldBonus(): number {
+        return this.isSkillUnlocked('skill_starting_gold') ? 50 : 0;
+    }
+
+    /**
+     * Get starting lives bonus
+     */
+    public getStartingLivesBonus(): number {
+        return this.isSkillUnlocked('skill_extra_lives') ? 5 : 0;
+    }
+
+    /**
+     * Save progression to localStorage
+     */
+    private saveProgress(): void {
+        try {
+            const data = {
+                version: CampaignProgressionService.STORAGE_VERSION,
+                campaignPoints: this.campaignPoints,
+                totalPointsEarned: this.totalPointsEarned,
+                unlockedTowers: Array.from(this.unlockedTowers),
+                unlockedSkills: Array.from(this.unlockedSkills)
+            };
+            localStorage.setItem(CampaignProgressionService.STORAGE_KEY, JSON.stringify(data));
+        } catch (error) {
+            console.error('Failed to save campaign progress:', error);
+        }
+    }
+
+    /**
+     * Load progression from localStorage
+     */
+    private loadProgress(): void {
+        try {
+            const savedData = localStorage.getItem(CampaignProgressionService.STORAGE_KEY);
+            if (savedData) {
+                const data = JSON.parse(savedData);
+                
+                // Check version - if version doesn't match or doesn't exist, reset
+                if (!data.version || data.version !== CampaignProgressionService.STORAGE_VERSION) {
+                    console.log('Campaign save version mismatch or missing. Resetting campaign progress...');
+                    this.resetProgress();
+                    return;
+                }
+                
+                this.campaignPoints = data.campaignPoints || 0;
+                this.totalPointsEarned = data.totalPointsEarned || 0;
+                this.unlockedTowers = new Set(data.unlockedTowers || [TowerTypeID.BASIC]);
+                this.unlockedSkills = new Set(data.unlockedSkills || []);
+            } else {
+                // First time playing - reset progress
+                console.log('No saved campaign progress found. Starting fresh...');
+                this.resetProgress();
+            }
+        } catch (error) {
+            console.error('Failed to load campaign progress:', error);
+            this.resetProgress();
+        }
+    }
+
+    /**
+     * Get statistics for display
+     */
+    public getStatistics(): {
+        campaignPoints: number;
+        totalPointsEarned: number;
+        towersUnlocked: number;
+        totalTowers: number;
+        skillsUnlocked: number;
+        totalSkills: number;
+    } {
+        const allItems = this.getAllUnlockableItems();
+        const towerItems = allItems.filter(item => item.type === 'tower');
+        const skillItems = allItems.filter(item => item.type === 'skill');
+
+        return {
+            campaignPoints: this.campaignPoints,
+            totalPointsEarned: this.totalPointsEarned,
+            towersUnlocked: this.unlockedTowers.size,
+            totalTowers: towerItems.length + 1, // +1 for basic tower which is always unlocked
+            skillsUnlocked: this.unlockedSkills.size,
+            totalSkills: skillItems.length
+        };
+    }
+}
+

--- a/src/services/CampaignProgressionService.ts
+++ b/src/services/CampaignProgressionService.ts
@@ -13,16 +13,6 @@ export interface UnlockableItem {
 }
 
 /**
- * Campaign progression data
- */
-interface CampaignProgressionData {
-    campaignPoints: number;
-    totalPointsEarned: number; // Track total points earned for statistics
-    unlockedTowers: Set<TowerTypeID>;
-    unlockedSkills: Set<string>;
-}
-
-/**
  * CampaignProgressionService - Singleton service to manage campaign progression
  * 
  * This service manages:
@@ -52,7 +42,7 @@ export class CampaignProgressionService {
         
         // Expose reset function to window for debugging (in browser console)
         if (typeof window !== 'undefined') {
-            (window as any).resetCampaign = () => {
+            (window as Window & { resetCampaign?: () => void }).resetCampaign = () => {
                 this.clearAndReset();
                 console.log('✅ Campaign progress has been reset! Reload the page to see changes.');
             };

--- a/src/services/GameConfigService.ts
+++ b/src/services/GameConfigService.ts
@@ -1,12 +1,15 @@
+import type { GameMode } from '../types';
+
 /**
  * GameConfigService - Singleton service to manage game configuration across the game
  * 
  * This service maintains global configuration states that persist across all scenes.
- * It provides methods to check and set the "brause" mode state.
+ * It provides methods to check and set the "brause" mode state and game mode.
  */
 export class GameConfigService {
     private static instance: GameConfigService;
     private _isBrauseMode: boolean = false;
+    private _gameMode: GameMode = 'quick-defense';
 
     /**
      * Private constructor to enforce singleton pattern
@@ -14,6 +17,8 @@ export class GameConfigService {
     private constructor() {
         // Initialize with brause mode disabled
         this._isBrauseMode = false;
+        // Default to quick defense mode
+        this._gameMode = 'quick-defense';
     }
 
     /**
@@ -47,5 +52,19 @@ export class GameConfigService {
     public toggleBrauseMode(): boolean {
         this._isBrauseMode = !this._isBrauseMode;
         return this._isBrauseMode;
+    }
+
+    /**
+     * Get the current game mode
+     */
+    public getGameMode(): GameMode {
+        return this._gameMode;
+    }
+
+    /**
+     * Set the game mode
+     */
+    public setGameMode(mode: GameMode): void {
+        this._gameMode = mode;
     }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -17,3 +17,11 @@ declare module 'phaser' {
 	}
 }
 
+// Game Mode Types
+export type GameMode = 'quick-defense' | 'campaign'
+
+// Campaign Progression Types
+export interface CampaignPoints {
+    points: number
+    totalEarned: number
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,8 +1,10 @@
 // Type declarations for browser APIs
-interface Window {
-	AudioContext: typeof AudioContext
-	webkitAudioContext?: typeof AudioContext
-	audioCtx?: AudioContext
+declare global {
+	interface Window {
+		AudioContext: typeof AudioContext
+		webkitAudioContext?: typeof AudioContext
+		audioCtx?: AudioContext
+	}
 }
 
 interface PhaserSound {


### PR DESCRIPTION
- Introduced campaign mode with a selection UI in StartScene.
- Implemented CampaignProgressionService to manage campaign points and unlockable items.
- Added UnlockScene for displaying and managing unlockable towers and skills.
- Updated GameScene and StatisticsScene to support campaign-specific features, including campaign points tracking.
- Enhanced UIScene to show only unlocked towers in campaign mode and added an unlock button.
- Refactored existing scenes to integrate campaign logic and improve overall gameplay experience.